### PR TITLE
fix(download): correctly set the arch/OS for Linux/ARMv7

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -19,7 +19,13 @@ fi
 
 case "$uname_s" in
 Darwin) os="apple-darwin" ;;
-Linux) os="unknown-linux-gnu" ;;
+Linux)
+	os="unknown-linux-gnu"
+	if [ "$uname_m" = "armv7l" ]; then
+		uname_m="armv7"
+		os="${os}eabihf"
+	fi
+	;;
 *) fail "OS not supported: $uname_s" ;;
 esac
 release_file="${TOOL_NAME}-${uname_m}-${os}.tar.gz"


### PR DESCRIPTION
This allows platforms such as the Raspberry Pi to download `uv`. Otherwise, installing it errors, and the output looks like this:

```
* Downloading uv release 0.4.18...
curl: (22) The requested URL returned error: 404
asdf-uv: Could not download https://github.com/astral-sh/uv/releases/download/0.4.18/uv-armv7l-unknown-linux-gnu.tar.gz
```

Note that the filename (at least as of [0.4.18](https://github.com/astral-sh/uv/releases/tag/0.4.18)) looks like this:

```
uv-armv7-unknown-linux-gnueabihf.tar.gz
```